### PR TITLE
Add catch for attempted registration with an email already in use

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -133,10 +133,13 @@ async def create_user(user: UserCreate, request: Request, db: AsyncSession = Dep
     if existing_user:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Username already exists")
     
+    existing_email = await UserService.get_by_email(db, user.email)
+    if existing_email:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already in use")
+    
     created_user = await UserService.create(db, user.model_dump())
     if not created_user:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create user")
-    
     
     return UserResponse.model_construct(
         id=created_user.id,


### PR DESCRIPTION
POST /users/ will no longer return 500: Internal Server Error on registration with an in-use email.

Resolves #7