### PR TITLE
Updated Gunicorn to 22.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ factory-boy==3.3.0
 Faker==24.4.0
 fastapi==0.110.0
 greenlet==3.0.3
-gunicorn==21.2.0
+gunicorn==22.0.0
 h11==0.14.0
 httpcore==1.0.5
 httpx==0.27.0


### PR DESCRIPTION
Tested all endpoints and ran all tests, no issues found after update
Gunicorn 22.0.0 fixes CVE-2024-1135
Resolves #13 